### PR TITLE
ZBUG-1176:- Missing search box in Online Help when using MacOS Safari

### DIFF
--- a/de/advanced/whfdhtml.htm
+++ b/de/advanced/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/de/advanced/whphost.js
+++ b/de/advanced/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/de/advanced/whver.js
+++ b/de/advanced/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/de/standard/whfdhtml.htm
+++ b/de/standard/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/de/standard/whphost.js
+++ b/de/standard/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/de/standard/whver.js
+++ b/de/standard/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/en_US/advanced/whfdhtml.htm
+++ b/en_US/advanced/whfdhtml.htm
@@ -46,7 +46,7 @@ if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 	var iFrameSetValue = 115;
 	if (gbMac)
 	{
-		iFrameSetValue = 85;
+		iFrameSetValue = 95;
 	}
 	
 	if(gbGiveAndSearch)

--- a/en_US/advanced/whphost.js
+++ b/en_US/advanced/whphost.js
@@ -152,7 +152,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/en_US/advanced/whver.js
+++ b/en_US/advanced/whver.js
@@ -132,7 +132,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/en_US/standard/whfdhtml.htm
+++ b/en_US/standard/whfdhtml.htm
@@ -46,7 +46,7 @@ if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 	var iFrameSetValue = 115;
 	if (gbMac)
 	{
-		iFrameSetValue = 85;
+		iFrameSetValue = 95;
 	}
 	
 	if(gbGiveAndSearch)

--- a/en_US/standard/whphost.js
+++ b/en_US/standard/whphost.js
@@ -152,7 +152,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/en_US/standard/whver.js
+++ b/en_US/standard/whver.js
@@ -132,7 +132,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/es/advanced/whfdhtml.htm
+++ b/es/advanced/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='120,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/es/advanced/whphost.js
+++ b/es/advanced/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/es/advanced/whver.js
+++ b/es/advanced/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/es/standard/whfdhtml.htm
+++ b/es/standard/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='120,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/es/standard/whphost.js
+++ b/es/standard/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/es/standard/whver.js
+++ b/es/standard/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/fr/advanced/whfdhtml.htm
+++ b/fr/advanced/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/fr/advanced/whphost.js
+++ b/fr/advanced/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/fr/advanced/whver.js
+++ b/fr/advanced/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/fr/standard/whfdhtml.htm
+++ b/fr/standard/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/fr/standard/whphost.js
+++ b/fr/standard/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/fr/standard/whver.js
+++ b/fr/standard/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/it/advanced/whfdhtml.htm
+++ b/it/advanced/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='120,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='120,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/it/advanced/whphost.js
+++ b/it/advanced/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/it/advanced/whver.js
+++ b/it/advanced/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/it/standard/whfdhtml.htm
+++ b/it/standard/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='120,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='120,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/it/standard/whphost.js
+++ b/it/standard/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/it/standard/whver.js
+++ b/it/standard/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/ja/advanced/whfdhtml.htm
+++ b/ja/advanced/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/ja/advanced/whphost.js
+++ b/ja/advanced/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/ja/advanced/whver.js
+++ b/ja/advanced/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/ja/standard/whfdhtml.htm
+++ b/ja/standard/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/ja/standard/whphost.js
+++ b/ja/standard/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/ja/standard/whver.js
+++ b/ja/standard/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/nl/advanced/whfdhtml.htm
+++ b/nl/advanced/whfdhtml.htm
@@ -37,7 +37,7 @@ var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
 	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
+		strWrite="<FRAMESET ROWS='95,100%' framespacing=0  frameborder=0>";
 	else
 		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";

--- a/nl/advanced/whphost.js
+++ b/nl/advanced/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/nl/advanced/whver.js
+++ b/nl/advanced/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/nl/standard/whfdhtml.htm
+++ b/nl/standard/whfdhtml.htm
@@ -37,7 +37,7 @@ var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
 	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
+		strWrite="<FRAMESET ROWS='95,100%' framespacing=0  frameborder=0>";
 	else
 		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";

--- a/nl/standard/whphost.js
+++ b/nl/standard/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/nl/standard/whver.js
+++ b/nl/standard/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/pt_BR/advanced/whfdhtml.htm
+++ b/pt_BR/advanced/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/pt_BR/advanced/whphost.js
+++ b/pt_BR/advanced/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/pt_BR/advanced/whver.js
+++ b/pt_BR/advanced/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/pt_BR/standard/whfdhtml.htm
+++ b/pt_BR/standard/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/pt_BR/standard/whphost.js
+++ b/pt_BR/standard/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/pt_BR/standard/whver.js
+++ b/pt_BR/standard/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/ru/advanced/whfdhtml.htm
+++ b/ru/advanced/whfdhtml.htm
@@ -37,7 +37,7 @@ var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
 	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
+		strWrite="<FRAMESET ROWS='160,100%' framespacing=0  frameborder=0>";
 	else
 		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";

--- a/ru/advanced/whphost.js
+++ b/ru/advanced/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/ru/advanced/whver.js
+++ b/ru/advanced/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/ru/standard/whfdhtml.htm
+++ b/ru/standard/whfdhtml.htm
@@ -37,7 +37,7 @@ var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
 	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
+		strWrite="<FRAMESET ROWS='160,100%' framespacing=0  frameborder=0>";
 	else
 		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";

--- a/ru/standard/whphost.js
+++ b/ru/standard/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/ru/standard/whver.js
+++ b/ru/standard/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/zh_CN/advanced/whfdhtml.htm
+++ b/zh_CN/advanced/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/zh_CN/advanced/whphost.js
+++ b/zh_CN/advanced/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/zh_CN/advanced/whver.js
+++ b/zh_CN/advanced/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/zh_CN/standard/whfdhtml.htm
+++ b/zh_CN/standard/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/zh_CN/standard/whphost.js
+++ b/zh_CN/standard/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/zh_CN/standard/whver.js
+++ b/zh_CN/standard/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/zh_HK/advanced/whfdhtml.htm
+++ b/zh_HK/advanced/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/zh_HK/advanced/whphost.js
+++ b/zh_HK/advanced/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/zh_HK/advanced/whver.js
+++ b/zh_HK/advanced/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;

--- a/zh_HK/standard/whfdhtml.htm
+++ b/zh_HK/standard/whfdhtml.htm
@@ -36,10 +36,7 @@ var gbIndexLayerInit = false;
 var strWrite="";
 if (window.gbWhVer&&window.gbWhProxy&&window.gbWhMsg)
 {
-	if (gbMac)
-		strWrite="<FRAMESET ROWS='85,100%' framespacing=0  frameborder=0>";
-	else
-		strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
+	strWrite="<FRAMESET ROWS='115,100%' framespacing=0  frameborder=0>";
 	strWrite +="<FRAME SRC='whfform.htm' title='search form frame' name='ftsform' noresize='yes' scrolling='no'>";
 	strWrite +="<FRAME SRC='whfbody.htm' title='search result frame' name='ftsbody' scrolling='yes'>";
 	strWrite +="</FRAMESET>";

--- a/zh_HK/standard/whphost.js
+++ b/zh_HK/standard/whphost.js
@@ -150,7 +150,7 @@ function whCom(sName,sComFile)
 		else if(gbUnixOS)
 			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:100%;visibility:hidden\">";
 		else
-			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.height+";visibility:hidden\">";
+			sHTML+="<DIV ID="+this.msDivId+" ALIGN=left STYLE=\"position:absolute;z-index:1;left:0;top:0;width:100%;height:"+parent.innerHeight+";visibility:hidden\">";
 		sHTML+="</DIV>";
 		return sHTML;
 	}

--- a/zh_HK/standard/whver.js
+++ b/zh_HK/standard/whver.js
@@ -130,7 +130,9 @@ if(gbSafari)
 	var nPos = gAgent.indexOf("version/");
 	if(nPos!=-1)
 	{
-		var nVersion = parseFloat(gAgent.substring(nPos+8,nPos+9));
+		var nVersionSplitArray = gAgent.substring(nPos+8).split(".");
+		var nVersion = parseFloat(nVersionSplitArray[0]);
+
 		if (nVersion >= 3)
 		{
 			gbSafari3=true;


### PR DESCRIPTION
Fixed issue - menu options sidebar data was not getting displayed due to height.

Updated code to correctly extract the safari version from user agent string.

Updated search frame row height as per language.