### PR TITLE
ZCS-2733 Added Makefile and circleci config to enable zimbra-help package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,105 @@
+version: 2.1
+orbs:
+  aws-s3: circleci/aws-s3@3.0.0
+
+############################################################################
+
+references:
+   checkout_job_steps: &checkout_job_steps
+      steps:
+         - checkout
+         - run: 
+            name: Checking out dependencies
+            command: |
+               git clone -b hotfix/speed-up-debian-package-creation --single-branch https://github.com/Zimbra/zm-pkg-tool.git ~/zm-pkg-tool
+               echo "BUILD_NO=$CIRCLE_BUILD_NUM" > config.build
+         - persist_to_workspace:
+            root: ..
+            paths:
+               - zm-help
+               - zm-pkg-tool
+
+   build_job_steps: &build_job_steps
+      steps:
+         - attach_workspace:
+            at: ..
+         - run:
+            name: Creating build
+            command: make
+         - store_artifacts:
+            path: build/dist
+         - persist_to_workspace:
+            root: ..
+            paths: zm-help/build/dist/*
+
+############################################################################
+
+jobs:
+   checkout:
+      working_directory: ~/zm-help
+      shell: /bin/bash -eo pipefail
+      docker:
+         - image: zimbra/zm-base-os:core-ubuntu
+      <<: *checkout_job_steps
+
+   build_u20:
+      working_directory: ~/zm-help
+      shell: /bin/bash -eo pipefail
+      docker:
+         - image: zimbra/zm-base-os:devcore-ubuntu-20.04
+      <<: *build_job_steps
+
+   build_u18:
+      working_directory: ~/zm-help
+      shell: /bin/bash -eo pipefail
+      docker:
+         - image: zimbra/zm-base-os:devcore-ubuntu-18.04
+      <<: *build_job_steps
+
+   build_u16:
+      working_directory: ~/zm-help
+      shell: /bin/bash -eo pipefail
+      docker:
+         - image: zimbra/zm-base-os:devcore-ubuntu-16.04
+      <<: *build_job_steps
+
+   build_c8:
+      working_directory: ~/zm-help
+      shell: /bin/bash -eo pipefail
+      docker:
+         - image: zimbra/zm-base-os:devcore-centos-8
+      <<: *build_job_steps
+
+   build_c7:
+      working_directory: ~/zm-help
+      shell: /bin/bash -eo pipefail
+      docker:
+         - image: zimbra/zm-base-os:devcore-centos-7
+      <<: *build_job_steps
+
+############################################################################
+
+workflows:
+   version: 2
+   main:
+      jobs:
+         - build:
+            type: approval
+         - checkout:
+            requires:
+              - build
+         - build_u20:
+            requires:
+               - checkout
+         - build_u18:
+            requires:
+               - checkout
+         - build_u16:
+            requires:
+               - checkout
+         - build_c8:
+            requires:
+               - checkout
+         - build_c7:
+            requires:
+               - checkout

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+########################################################################################################
+
+SHELL=bash
+NAME = zimbra-help
+DESC = Package for getting help files installed for web client users.
+
+########################################################################################################
+
+all: zimbra-help-pkg
+
+########################################################################################################
+
+stage-help-files:
+	mkdir -p build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/
+	cp -r en_US build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/en_US
+	cp -r de build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/de
+	cp -r es build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/es
+	cp -r fr build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/fr
+	cp -r it build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/it
+	cp -r ja build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/ja
+	cp -r nl build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/nl
+	cp -r pt_BR build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/pt_BR
+	cp -r ru build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/ru
+	cp -r zh_CN build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/zh_CN
+	cp -r zh_HK build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/zh_HK
+
+zimbra-help-pkg: stage-help-files
+	../zm-pkg-tool/pkg-build.pl \
+		--out-type=binary \
+		--pkg-version=1.0.0 \
+		--pkg-release=1 \
+		--pkg-name=$(NAME) \
+		--pkg-summary='$(DESC)' \
+		--pkg-depends='zimbra-store (>= 8.8.15)' \
+		--pkg-installs='/opt/zimbra/jetty_base/webapps/zimbra/help'
+
+########################################################################################################

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ all: zimbra-help-pkg
 
 stage-help-files:
 	mkdir -p build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/
-	cp -r en_US build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/en_US
 	cp -r de build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/de
+	cp -r en_US build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/en_US
 	cp -r es build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/es
 	cp -r fr build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/fr
 	cp -r it build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/it


### PR DESCRIPTION
The product help pages will be excluded from next build and patches. This code includes a Makefile to create "zimbra-help" package which can be installed to include the product help pages back in the build.
Please check the related PRs in the reference section.