### PR TITLE
ZCS-2733: changed the stage path of zimbra-help package contents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,28 +11,29 @@ all: zimbra-help-pkg
 ########################################################################################################
 
 stage-help-files:
-	mkdir -p build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/
-	cp -r de build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/de
-	cp -r en_US build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/en_US
-	cp -r es build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/es
-	cp -r fr build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/fr
-	cp -r it build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/it
-	cp -r ja build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/ja
-	cp -r nl build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/nl
-	cp -r pt_BR build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/pt_BR
-	cp -r ru build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/ru
-	cp -r zh_CN build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/zh_CN
-	cp -r zh_HK build/stage/$(NAME)/opt/zimbra/jetty_base/webapps/zimbra/help/zh_HK
+	mkdir -p build/stage/$(NAME)/opt/zimbra/lib/$(NAME)/
+	cp -r de build/stage/$(NAME)/opt/zimbra/lib/$(NAME)/de
+	cp -r en_US build/stage/$(NAME)/opt/zimbra/lib/$(NAME)/en_US
+	cp -r es build/stage/$(NAME)/opt/zimbra/lib/$(NAME)/es
+	cp -r fr build/stage/$(NAME)/opt/zimbra/lib/$(NAME)/fr
+	cp -r it build/stage/$(NAME)/opt/zimbra/lib/$(NAME)/it
+	cp -r ja build/stage/$(NAME)/opt/zimbra/lib/$(NAME)/ja
+	cp -r nl build/stage/$(NAME)/opt/zimbra/lib/$(NAME)/nl
+	cp -r pt_BR build/stage/$(NAME)/opt/zimbra/lib/$(NAME)/pt_BR
+	cp -r ru build/stage/$(NAME)/opt/zimbra/lib/$(NAME)/ru
+	cp -r zh_CN build/stage/$(NAME)/opt/zimbra/lib/$(NAME)/zh_CN
+	cp -r zh_HK build/stage/$(NAME)/opt/zimbra/lib/$(NAME)/zh_HK
 
 zimbra-help-pkg: stage-help-files
 	../zm-pkg-tool/pkg-build.pl \
 		--out-type=binary \
-		--pkg-version=1.0.0 \
+		--pkg-version=1.0.0.$(shell git log --format=%at -1) \
 		--pkg-release=1 \
 		--pkg-name=$(NAME) \
 		--pkg-summary='$(DESC)' \
 		--pkg-pre-install-script='scripts/preinst.sh' \
+		--pkg-post-install-script='scripts/postinst.sh' \
 		--pkg-depends='zimbra-store (>= 8.8.15)' \
-		--pkg-installs='/opt/zimbra/jetty_base/webapps/zimbra/help'
+		--pkg-installs='/opt/zimbra/lib/$(NAME)'
 
 ########################################################################################################

--- a/scripts/postinst.sh
+++ b/scripts/postinst.sh
@@ -1,0 +1,6 @@
+if [ -d /opt/zimbra/jetty_base/webapps/zimbra ]; then
+    mkdir -p /opt/zimbra/jetty_base/webapps/zimbra/help
+    cp -r /opt/zimbra/lib/zimbra-help/* /opt/zimbra/jetty_base/webapps/zimbra/help/
+    rm -rf /opt/zimbra/lib/zimbra-help
+fi
+echo "**** Completed zimbra-help package installation ****"


### PR DESCRIPTION
The staging path of zimbra-help package content was conflicting with the zimbra-store staging path. Modified the path and added the postinst.sh script to copy the package content in correct location.