### PR TITLE
ZCS-13921: Added Ubuntu22 build steps in the circleci config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,16 @@ jobs:
          - image: zimbra/zm-base-os:core-ubuntu
       <<: *checkout_job_steps
 
+   build_u22:
+      working_directory: ~/zm-help
+      shell: /bin/bash -eo pipefail
+      docker:
+         - image: $DOCKER_REGISTRY/zm-base-os:devcore-ubuntu-22.04
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
+      <<: *build_job_steps
+
    build_u20:
       working_directory: ~/zm-help
       shell: /bin/bash -eo pipefail
@@ -108,6 +118,11 @@ workflows:
          - checkout:
             requires:
               - build
+         - build_u22:
+            requires:
+               - checkout
+            context:
+               - docker-dev-registry
          - build_u20:
             requires:
                - checkout
@@ -127,6 +142,7 @@ workflows:
          - deploy_s3_hold:
             type: approval
             requires:
+               - build_u22
                - build_u20
                - build_u18
                - build_u16


### PR DESCRIPTION
**ZCS-13921: Added Ubuntu22 build steps in the circleci config.**

- Updated the circle-ci config.yaml file with new job to build Ubuntu 22 packages.
- Included the job into available workflows.

**Note**
- For all OS versions other than U22 we are pulling images from zimbra/ public docker image registry.
- For U22 OS version we are pulling the base image from private docker dev images registry.
- Thats why I have added the `contexts: docker-dev-registry` in the workflow.