### PR TITLE
ZCS-14269: Use private docker images registry instead of public registry.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,21 +71,30 @@ jobs:
       working_directory: ~/zm-help
       shell: /bin/bash -eo pipefail
       docker:
-         - image: zimbra/zm-base-os:devcore-ubuntu-20.04
+         - image: $DOCKER_REGISTRY/zm-base-os:devcore-ubuntu-20.04
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
       <<: *build_job_steps
 
    build_u18:
       working_directory: ~/zm-help
       shell: /bin/bash -eo pipefail
       docker:
-         - image: zimbra/zm-base-os:devcore-ubuntu-18.04
+         - image: $DOCKER_REGISTRY/zm-base-os:devcore-ubuntu-18.04
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
       <<: *build_job_steps
 
    build_u16:
       working_directory: ~/zm-help
       shell: /bin/bash -eo pipefail
       docker:
-         - image: zimbra/zm-base-os:devcore-ubuntu-16.04
+         - image: $DOCKER_REGISTRY/zm-base-os:devcore-ubuntu-16.04
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
       <<: *build_job_steps
 
    build_c9:
@@ -102,14 +111,20 @@ jobs:
       working_directory: ~/zm-help
       shell: /bin/bash -eo pipefail
       docker:
-         - image: zimbra/zm-base-os:devcore-centos-8
+         - image: $DOCKER_REGISTRY/zm-base-os:devcore-centos-8
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
       <<: *build_job_steps
 
    build_c7:
       working_directory: ~/zm-help
       shell: /bin/bash -eo pipefail
       docker:
-         - image: zimbra/zm-base-os:devcore-centos-7
+         - image: $DOCKER_REGISTRY/zm-base-os:devcore-centos-7
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
       <<: *build_job_steps
 
    deploy_s3:
@@ -136,12 +151,18 @@ workflows:
          - build_u20:
             requires:
                - checkout
+            context:
+               - docker-dev-registry
          - build_u18:
             requires:
                - checkout
+            context:
+               - docker-dev-registry
          - build_u16:
             requires:
                - checkout
+            context:
+               - docker-dev-registry
          - build_c9:
             requires:
                - checkout
@@ -150,9 +171,13 @@ workflows:
          - build_c8:
             requires:
                - checkout
+            context:
+               - docker-dev-registry
          - build_c7:
             requires:
                - checkout
+            context:
+               - docker-dev-registry
          
          - deploy_s3_hold:
             type: approval


### PR DESCRIPTION
**ZCS-14269: Use private docker images registry instead of public registry.**

- Using synacor's OCI dev/ image registry to pull images instead of using images from zimbra/zm-base-os public docker registry.